### PR TITLE
WebSQL : Fix getSchema when having more than one multi-entry index.

### DIFF
--- a/src/ydn/db/conn/websql.js
+++ b/src/ydn/db/conn/websql.js
@@ -655,19 +655,21 @@ ydn.db.con.WebSql.prototype.getSchema = function(callback, trans, db) {
             var st_name = names[1];
             var multi_index = new ydn.db.schema.Index(names[2], type,
                 unique, true);
-            var ex_index = goog.array.findIndex(indexes, function(x) {
-              return x.getName() == names[2];
-            });
-            if (ex_index >= 0) {
-              indexes[ex_index] = multi_index;
-            } else {
-              indexes.push(multi_index);
-            }
+
             var store_index = goog.array.findIndex(stores, function(x) {
               return x.getName() === st_name;
             });
             if (store_index >= 0) { // main table exist, add this index
               var ex_store = stores[store_index];
+              indexes = ex_store.indexes;              
+              var ex_index = goog.array.findIndex(indexes, function(x) {
+                return x.getName() == names[2];
+              });
+              if (ex_index >= 0) {
+                indexes[ex_index] = multi_index;
+              } else {
+                indexes.push(multi_index);
+              }
               stores[store_index] = new ydn.db.schema.Store(ex_store.getName(),
                   ex_store.getKeyPath(), autoIncrement,
                   key_type, indexes, undefined, !has_default_blob_column);
@@ -687,9 +689,7 @@ ydn.db.con.WebSql.prototype.getSchema = function(callback, trans, db) {
             return x.getName() === info.name;
           });
           if (i_store >= 0) {
-            var ex_index = stores[i_store].index(0);
-            goog.asserts.assertInstanceof(ex_index, ydn.db.schema.Index);
-            indexes.push(ex_index);
+            goog.array.extend(indexes, stores[i_store].indexes);
             stores[i_store] = new ydn.db.schema.Store(info.name, store_key_path,
                 autoIncrement, key_type, indexes, undefined,
                 !has_default_blob_column);


### PR DESCRIPTION
In WebSQL implementation multi-entry indexes are stored in a separate
table. Each 'multientry' table is composed of two columns, one which
name match the multi-entry index name and one column 'id'.
What we expect getSchema method to do is :
When parsing a 'multientry' table,
- If there already is an entry in the stores map, add the multi-entry index
 to the entry
- if not, create an entry in the stores map with only the multi-entry index
When parsing the 'store' table :
- If there already is an entry in the stores map, merge all indexes of the
  entry with those of the 'store' table.
What getSchema was doing :
When parsing a 'multientry' table :
- If there already is an entry in the stores map, replace all indexes of
  the entry by the multientry table indexes (id + multientry index)
- if not, it works as expected.
When parsing the 'store' table :
- if there already is an entry in the stores map, add only the first
  recorded index to the store indexes
So if :
- Store is parsed before the multientry table (which happens rarely
  ) the store indexes are overwritten by the multientry table indexes.
- There is more than one multi-entry index, only one of the multi entry
  indexes is added to the store description.