### PR TITLE
Bugfix/90

### DIFF
--- a/src/ydn/db/conn/simple/store.js
+++ b/src/ydn/db/conn/simple/store.js
@@ -189,16 +189,18 @@ ydn.db.con.simple.Store.prototype.getIndexCache = function(opt_index_name) {
               var index = this.schema.getIndex(index_name);
               var obj = ydn.json.parse(obj_str);
               var index_key = /** @type {IDBKey} */ (index.extractKey(obj));
-              if (index.isMultiEntry()) {
-                if (goog.isArray(index_key)) {
-                  for (var k = 0; k < index_key.length; k++) {
-                    var i_node = new ydn.db.con.simple.Node(index_key[k], key);
-                    this.key_indexes[index_name].add(i_node);
+              if (index_key) {
+                if (index.isMultiEntry()) {
+                  if (goog.isArray(index_key)) {
+                    for (var k = 0; k < index_key.length; k++) {
+                      var i_node = new ydn.db.con.simple.Node(index_key[k], key);
+                      this.key_indexes[index_name].add(i_node);
+                    }
                   }
+                } else {
+                  var index_node = new ydn.db.con.simple.Node(index_key, key);
+                  this.key_indexes[index_name].add(index_node);
                 }
-              } else {
-                var index_node = new ydn.db.con.simple.Node(index_key, key);
-                this.key_indexes[index_name].add(index_node);
               }
             }
           }

--- a/src/ydn/db/core/req/simple_cursor.js
+++ b/src/ydn/db/core/req/simple_cursor.js
@@ -366,6 +366,9 @@ ydn.db.core.req.SimpleCursor.prototype.openCursor = function(
      * @return {boolean|undefined} continuation.
      */
     var onSuccess = function(node) {
+      if (!node) {
+        return this.defaultOnSuccess_(node);
+      }
       var x = /** @type {ydn.db.con.simple.Node} */ (node.value);
       var key = x.getKey();
       // console.log('on ', x);


### PR DESCRIPTION
This PR is related to the PR in ydn-base (from the branch with the same name). It's mean to support call of onSuccess in the simple_cursor with a null parameter.
Another fix was necessary to make indexCursor work with simple storage : The index cache was trying to add entries for storage entries without value for the given index which was throwing a ""Failed to execute 'cmp' on 'IDBFactory': The parameter is not a valid key.". The second commit skip storage entries without values for the index .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yathit/ydn-db/112)
<!-- Reviewable:end -->
