### PR TITLE
Fix #90 : For index name comparaison indexOf is used instead of ==

### DIFF
--- a/src/ydn/db/base/schema/store.js
+++ b/src/ydn/db/base/schema/store.js
@@ -894,7 +894,7 @@ ydn.db.schema.Store.prototype.hintForWebSql = function(that) {
     if (that.indexes[i].isComposite()) {
       var name = that.indexes[i].getName();
       for (var j = indexes.length - 1; j >= 0; j--) {
-        if (name.indexOf(indexes[j].getName()) >= 0) {
+        if (name == indexes[j].getName()) {
           indexes[j] = that.indexes[i].clone();
           break;
         }


### PR DESCRIPTION
When using indexOf instead of == if a index name partially match
compouned index name, both index are considered as equal by the code.

IndexOf seems to be used because 'name' var is threated as an array.
getName definition states that the return type is a string so this fix
should be safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yathit/ydn-db/113)
<!-- Reviewable:end -->
